### PR TITLE
Fixed uint32_t calculation overflow bug in ddb_list

### DIFF
--- a/src/ddb_list.c
+++ b/src/ddb_list.c
@@ -34,7 +34,7 @@ struct ddb_list *ddb_list_append(struct ddb_list *list, uintptr_t e)
             list->size = UINT32_MAX;
         else
             list->size += LIST_INCREMENT;
-        if (!(list = realloc(list, sizeof(struct ddb_list) + list->size * 8)))
+        if (!(list = realloc(list, sizeof(struct ddb_list) + (uint64_t)list->size * 8)))
             return NULL;
     }
     if (list->i == UINT32_MAX)


### PR DESCRIPTION
The calculation of the size of the next increment of `list->list` is being calculated using `uint32_t` sized integers, yet it is possible that the calculation can exceed the maximum value of `uint32_t`. Encountering this case causes the array of `list->list` to shrink suddenly to the calculated size minus the max `uint32_t` value, yet `list->size` still increases to imply that there is more space available then there is. Later, when the next element is attempted to be added, the value of `list->i` goes beyond the allocated space of `list->list` and causes the program to segfault.
