### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ See documentation at http://discodb.readthedocs.org
 Use the Makefile to build, e.g.::
 
     make
-    make erlang
     make python
     make python CMD=install
     make utils


### PR DESCRIPTION
rm `make erlang` build instruction, since it's invalid